### PR TITLE
Check modulus of forged public key, add new issue if length is below 2048 bits.

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,12 +2,12 @@ Uuid: f13f85e71b9a4bac853ab8a38147a2e1
 ExtensionType: 1
 Name: JWT Scanner
 RepoName: jwt-scanner
-ScreenVersion: 2.0.0
-SerialVersion: 2
+ScreenVersion: 2.1.0
+SerialVersion: 3
 MinPlatformVersion: 0
 ProOnly: False
 Author: Dario Caluzi / Cyrill Bannwart / Tobias Hort-Giess
 ShortDescription: JWT Scanner is a Burp Suite extension for automated testing of JSON Web Token (JWT) implementations of web applications. 
-EntryPoint: build/libs/jwt-scanner-2.0.0.jar
+EntryPoint: build/libs/jwt-scanner-2.1.0.jar
 BuildCommand: ./gradlew jar
 SupportedProducts: Pro

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java-library"
 }
 
-version = "2.0.0"
+version = "2.1.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/ch/csnc/burp/jwtscanner/ContextMenu.java
+++ b/src/main/java/ch/csnc/burp/jwtscanner/ContextMenu.java
@@ -6,8 +6,8 @@ import burp.api.montoya.ui.contextmenu.ContextMenuEvent;
 import burp.api.montoya.ui.contextmenu.MessageEditorHttpRequestResponse;
 import ch.csnc.burp.jwtscanner.checks.Checks;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JMenuItem;
+import java.awt.Component;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/ch/csnc/burp/jwtscanner/ContextMenu.java
+++ b/src/main/java/ch/csnc/burp/jwtscanner/ContextMenu.java
@@ -8,6 +8,7 @@ import ch.csnc.burp.jwtscanner.checks.Checks;
 
 import javax.swing.*;
 import java.awt.*;
+import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -53,6 +54,12 @@ public class ContextMenu implements burp.api.montoya.ui.contextmenu.ContextMenuI
                                         JwtScannerExtension.storage().putForgedPublicKeys(publicKeys);
                                         siteMap.add(JwtAuditIssues.forgedPublicKeys(menuEvent.selectedRequestResponses().getFirst(), jwt1, jwt2, publicKeys));
                                         JwtScannerExtension.logging().raiseInfoEvent("forging public keys was successful.");
+                                        // Raise an issue if modulus bit length is less than 2048 bit
+                                        for (RSAPublicKey publicKey : publicKeys) {
+                                            if (publicKey.getModulus().bitLength() < 2048) {
+                                                siteMap.add(JwtAuditIssues.forgedPublicKeyWeakModulus(menuEvent.selectedRequestResponses().getFirst(), jwt1, jwt2, publicKey));
+                                            }
+                                        }
                                     } else {
                                         JwtScannerExtension.logging().raiseInfoEvent("no public keys could be forged.");
                                     }

--- a/src/main/java/ch/csnc/burp/jwtscanner/JwtAuditIssues.java
+++ b/src/main/java/ch/csnc/burp/jwtscanner/JwtAuditIssues.java
@@ -387,7 +387,11 @@ public abstract class JwtAuditIssues {
                         <p>
                             Forged public keys:<br>
                             <pre>%s</pre>
-                        </p>""".formatted(jwt1.encode(), jwt2.encode(), publicKeys.stream().map(Rsa::publicKeyToPem).collect(Collectors.joining("<br>"))),
+                        </p>""".formatted(jwt1.encode(), jwt2.encode(), publicKeys.stream().map(key ->  """
+                                                                                                                     %s
+                                                                                                                     modulus size = %d bit
+                                                                                                                     """.formatted(Rsa.publicKeyToPem(key), key.getModulus().bitLength()))
+                                                                                           .collect(Collectors.joining("<br>"))),
                 "",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.MEDIUM,
@@ -395,6 +399,31 @@ public abstract class JwtAuditIssues {
                 null,
                 null,
                 AuditIssueSeverity.MEDIUM,
+                List.of());
+    }
+
+    public static AuditIssue forgedPublicKeyWeakModulus(HttpRequestResponse baseRequestResponse, Jwt jwt1, Jwt jwt2, RSAPublicKey publicKey) {
+        return auditIssue("Weak Public Key",
+                """
+                    <p>
+                        A public key was forged from the two JWT
+                        <pre>%s</pre>
+                        and
+                        <pre>%s</pre>
+                    </p>
+                    <br>
+                    <p>
+                        This public key has a modulus of <b>%d bits</b>.
+                        <br>It is recommended to use a modulus of at least 2048 bits.
+                    </p>
+                """.formatted(jwt1.encode(), jwt2.encode(), publicKey.getModulus().bitLength()),
+        "",
+                baseRequestResponse.request().url(),
+                AuditIssueSeverity.HIGH,
+                AuditIssueConfidence.FIRM,
+                null,
+                null,
+                AuditIssueSeverity.HIGH,
                 List.of());
     }
 }

--- a/src/main/java/ch/csnc/burp/jwtscanner/JwtAuditIssues.java
+++ b/src/main/java/ch/csnc/burp/jwtscanner/JwtAuditIssues.java
@@ -38,7 +38,7 @@ public abstract class JwtAuditIssues {
                           Try to crack it:
                           <pre>hashcat -a 0 -m 16500 <YOUR-JWT> /path/to/jwt.secrets.list</pre>
                         </p>""".formatted(alg),
-                "",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.INFORMATION,
                 confidence,
@@ -53,7 +53,7 @@ public abstract class JwtAuditIssues {
         return auditIssue(
                 "JWT is signed asymmetrically",
                 "alg: %s".formatted(alg.orElseThrow()),
-                "",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.INFORMATION,
                 confidence,
@@ -68,7 +68,7 @@ public abstract class JwtAuditIssues {
         return auditIssue(
                 "JWT has unknown algorithm",
                 "alg: %s".formatted(alg),
-                "",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.HIGH,
                 confidence,
@@ -81,8 +81,8 @@ public abstract class JwtAuditIssues {
     public static AuditIssue jwtDetected(Jwt jwt, AuditIssueConfidence confidence, HttpRequestResponse baseRequestResponse, HttpRequestResponse... checkRequestResponses) {
         return auditIssue(
                 "JWT detected",
-                "",
-                "",
+                "N/A",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.INFORMATION,
                 confidence,
@@ -97,7 +97,7 @@ public abstract class JwtAuditIssues {
         return auditIssue(
                 "JSON Web Key in header detected",
                 "jwk: %s".formatted(jwt.getJwk().orElseThrow()),
-                "",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.INFORMATION,
                 confidence,
@@ -111,7 +111,7 @@ public abstract class JwtAuditIssues {
         return auditIssue(
                 "JSON Web Key Sets detected",
                 "jku: %s".formatted(jwt.getJku().orElseThrow()),
-                "",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.INFORMATION,
                 confidence,
@@ -125,7 +125,7 @@ public abstract class JwtAuditIssues {
         return auditIssue(
                 "JSON Web Key Sets detected",
                 checkRequestResponses[0].request().url(),
-                "",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.INFORMATION,
                 confidence,
@@ -137,8 +137,8 @@ public abstract class JwtAuditIssues {
 
     public static AuditIssue expired(Jwt jwt, AuditIssueConfidence confidence, HttpRequestResponse baseRequestResponse, HttpRequestResponse... checkRequestResponses) {
         return auditIssue("JWT expired",
-                "",
-                "",
+                "N/A",
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.INFORMATION,
                 confidence,
@@ -384,18 +384,19 @@ public abstract class JwtAuditIssues {
                             JWT 2:
                             <pre>%s</pre>
                         </p>
-                        <p>
-                            Forged public keys:
-                            <pre>%s</pre>
-                        </p>""".formatted(
+                        %s""".formatted(
                         jwt1.encode(),
                         jwt2.encode(),
-                        publicKeys.stream().map(key -> """
-                                        %s
-                                        modulus size = %d bit
+                        publicKeys.stream()
+                                .map((key) -> """
+                                        <p>
+                                            Forged public key:
+                                            <pre>%s</pre>
+                                            modulus size = %d bit
+                                        </p>
                                         """.formatted(Rsa.publicKeyToPem(key), key.getModulus().bitLength()))
-                                .collect(Collectors.joining("<br>"))),
-                "",
+                                .collect(Collectors.joining("\n"))),
+                "N/A",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.MEDIUM,
                 AuditIssueConfidence.FIRM,
@@ -424,11 +425,10 @@ public abstract class JwtAuditIssues {
                                 <pre>%s</pre>
                             </p>
                             <p>
-                                This public key has a modulus of <b>%d bits</b>.<br>
-                                It is recommended to use a modulus of at least 2048 bits.
+                                This public key has a modulus of <b>%d bits</b>.
                             </p>
                         """.formatted(jwt1.encode(), jwt2.encode(), Rsa.publicKeyToPem(publicKey), publicKey.getModulus().bitLength()),
-                "",
+                "It is recommended to use a modulus of at least 2048 bits.",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.HIGH,
                 AuditIssueConfidence.FIRM,

--- a/src/main/java/ch/csnc/burp/jwtscanner/JwtAuditIssues.java
+++ b/src/main/java/ch/csnc/burp/jwtscanner/JwtAuditIssues.java
@@ -377,21 +377,24 @@ public abstract class JwtAuditIssues {
         return auditIssue("JWT public key successfully forged",
                 """
                         <p>
-                            JWT 1:<br>
+                            JWT 1:
                             <pre>%s</pre>
                         </p>
                         <p>
-                            JWT 2:<br>
+                            JWT 2:
                             <pre>%s</pre>
                         </p>
                         <p>
-                            Forged public keys:<br>
+                            Forged public keys:
                             <pre>%s</pre>
-                        </p>""".formatted(jwt1.encode(), jwt2.encode(), publicKeys.stream().map(key ->  """
-                                                                                                                     %s
-                                                                                                                     modulus size = %d bit
-                                                                                                                     """.formatted(Rsa.publicKeyToPem(key), key.getModulus().bitLength()))
-                                                                                           .collect(Collectors.joining("<br>"))),
+                        </p>""".formatted(
+                        jwt1.encode(),
+                        jwt2.encode(),
+                        publicKeys.stream().map(key -> """
+                                        %s
+                                        modulus size = %d bit
+                                        """.formatted(Rsa.publicKeyToPem(key), key.getModulus().bitLength()))
+                                .collect(Collectors.joining("<br>"))),
                 "",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.MEDIUM,
@@ -405,19 +408,27 @@ public abstract class JwtAuditIssues {
     public static AuditIssue forgedPublicKeyWeakModulus(HttpRequestResponse baseRequestResponse, Jwt jwt1, Jwt jwt2, RSAPublicKey publicKey) {
         return auditIssue("Weak Public Key",
                 """
-                    <p>
-                        A public key was forged from the two JWT
-                        <pre>%s</pre>
-                        and
-                        <pre>%s</pre>
-                    </p>
-                    <br>
-                    <p>
-                        This public key has a modulus of <b>%d bits</b>.
-                        <br>It is recommended to use a modulus of at least 2048 bits.
-                    </p>
-                """.formatted(jwt1.encode(), jwt2.encode(), publicKey.getModulus().bitLength()),
-        "",
+                            <p>
+                                The following public key was forged from the two JWTs.
+                            </p>
+                            <p>
+                                JWT 1:
+                                <pre>%s</pre>
+                            </p>
+                            <p>
+                                JWT 2:
+                                <pre>%s</pre>
+                            </p>
+                            <p>
+                                Forged public key:
+                                <pre>%s</pre>
+                            </p>
+                            <p>
+                                This public key has a modulus of <b>%d bits</b>.<br>
+                                It is recommended to use a modulus of at least 2048 bits.
+                            </p>
+                        """.formatted(jwt1.encode(), jwt2.encode(), Rsa.publicKeyToPem(publicKey), publicKey.getModulus().bitLength()),
+                "",
                 baseRequestResponse.request().url(),
                 AuditIssueSeverity.HIGH,
                 AuditIssueConfidence.FIRM,


### PR DESCRIPTION
If a public key is forged from two JWT, the size of the modulus is printed out in the audit issue.
![jwtscanner_issue_forged](https://github.com/user-attachments/assets/ab4baf2a-73c3-407a-b940-cafb28c5ff41)

Furthermore, a new issue is raised if the modulus is smaller than 2048 bit.
![jwtscanner_issue_weak](https://github.com/user-attachments/assets/1725c8ef-1ac8-4654-9026-f54a7268d978)
